### PR TITLE
【WIP】Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|title|text|null: false|
+|name|string|null: false|
 ### Association
 - has_many :messages
 - has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -27,20 +27,21 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
+|name|string|null: false, index: true|
 |email|string|null: false|
 |password|string|null: false|
 ### Association
 - has_many :messages
+- has_many :groups_users
 - has_many :groups, through: :groups_users
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |title|text|null: false|
-|user_id|integer|null: false, foreign_key: true|
 ### Association
 - has_many :messages
+- has_many :groups_users
 - has_many :users, through: :groups_users
 
 ## messagesテーブル
@@ -48,8 +49,8 @@ Things you may want to cover:
 |------|----|-------|
 |text|text||
 |image|text||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|reference|null: false, foreign_key: true|
+|group|reference|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group
@@ -57,8 +58,8 @@ Things you may want to cover:
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|reference|null: false, foreign_key: true|
+|group|reference|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -22,3 +22,43 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# Chat-Space DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups, through: :groups_users
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|title|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- has_many :messages
+- has_many :users, through: :groups_users
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text||
+|image|text||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group


### PR DESCRIPTION
# Why
DB設計の把握のため、READMEへ一覧を記載。

# What
user管理のためのusersテーブルが必要になるので記載。
groupを作成してmessageを投稿する機能があるため、groupsおよびmessagesテーブル。
また、usersとgroupsは多対多のリレーションになるため、中間テーブルであるgroups_usersテーブルの設定。