### PR TITLE
Add-Automatic-update

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class="message__upper-info">
             <div class="message__upper-info__talker">
               ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
       return html;
     } else {
       var html =
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class="message__upper-info">
             <div class="message__upper-info__talker">
               ${message.user_name}
@@ -62,4 +62,29 @@ $(function(){
       alert("メッセージ送信に失敗しました")
     });
   });
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function(){
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id  > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__upper-info
     .message__upper-info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
## Why

自動更新を行うことにより、手動でリロードせずに最新の投稿を読み込めるようにする。
最近のチャットアプリ全てこの機能が実装されているため、遅れをとらぬよう。

## What

・メッセージのidが確認できるように属性を指定する。
・idを取得し、新規投稿を判別できるように設定する。
・アクションを設定し、それを呼び出せるようルーティングを追加。
・投稿内容を受け取れるようにする。
・reloadMessage関数を作成し、取得したデータを表示できるようにする。
・取得したデータをメッセージ一覧に追加するための設定をするl。
・setInterval()関数を使用し、reloadMessageを指定の間隔で自動で読み込む。
・メッセージを読み込んだら自動で最新メッセージにスクロールするように設定。
・自動更新が必要ない画面で行わないよう指定を追加。

![Check-Automatic-update-function](https://user-images.githubusercontent.com/63147677/82729197-82ff9380-9d30-11ea-8465-e3194bc2f3a1.gif)
